### PR TITLE
fix error: object of type map has no len()

### DIFF
--- a/trim_osc.py
+++ b/trim_osc.py
@@ -48,7 +48,7 @@ def poly_parse(fp):
             data = True
             hole = l[0] == '!'
         elif l and data:
-            poly.append(map(lambda x: float(x.strip()), l.split()[:2]))
+            poly.append(list(map(lambda x: float(x.strip()), l.split()[:2])))
     return result
 
 


### PR DESCRIPTION
When I use '-p' option (polygon file), I got a error.

```
Traceback (most recent call last):
  File "shapely/speedups/_speedups.pyx", line 234, in shapely.speedups._speedups.geos_linearring_from_py
AttributeError: 'list' object has no attribute '__array_interface__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/osm/src/regional/trim_osc.py", line 91, in <module>
    tpoly = poly_parse(options.poly)
  File "/home/osm/src/regional/trim_osc.py", line 44, in poly_parse
    result = Polygon(poly)
  File "/home/osm/.local/lib/python3.5/site-packages/shapely/geometry/polygon.py", line 240, in __init__
    ret = geos_polygon_from_py(shell, holes)
  File "/home/osm/.local/lib/python3.5/site-packages/shapely/geometry/polygon.py", line 494, in geos_polygon_from_py
    ret = geos_linearring_from_py(shell)
  File "shapely/speedups/_speedups.pyx", line 319, in shapely.speedups._speedups.geos_linearring_from_py
TypeError: object of type 'map' has no len()
```

I guess this error caused by map function which returns map object on Python3.
So I use list function to cast list object.