### PR TITLE
fix: query _rels for relations instead of _ways

### DIFF
--- a/trim_osc.py
+++ b/trim_osc.py
@@ -173,7 +173,7 @@ for rel in root.iter('relation'):
         relations.append(int(rel.get('id')))
 
 q3 = 'select id from {0}_rels where id = ANY(%s);'.format(prefix)
-cur.execute(q2, (relations,))
+cur.execute(q3, (relations,))
 for row in cur:
     relations.remove(row[0])
 


### PR DESCRIPTION
Probably due to a typo, the script did run a query on planet_osm_ways to find relations included in the database.
This leads to all relations from the input file being kept in the list of relations outside of DB and further on removal of
all changed relations from osc files.

Changing used query from q2 to q3 to use planet_osm_rels.

This fixes #13